### PR TITLE
Add Apple Cocoa Core Timestamp 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This python script provides the following conversions from existing timestamps:
 - HFS(+) LE, HFS Local, HFS+ UTC
 - Hotmail
 - iOS 11
-- iOS Binary Plist (Mac Absolute + milli/nano seconds)
+- iOS Binary Plist/Cocoa Core (Mac Absolute + milli/nano seconds)
 - KSUID 27-character
 - KSUID 9-digit
 - Mac Absolute Time

--- a/TYPES.md
+++ b/TYPES.md
@@ -17,7 +17,7 @@
 - HFS(+) LE, HFS Local, HFS+ UTC
 - Hotmail
 - iOS 11
-- iOS Binary Plist
+- iOS Binary Plist/Cocoa Core
 - KSUID 27-character
 - KSUID 9-digit
 - Mac Absolute Time

--- a/time_decode/time_decode.py
+++ b/time_decode/time_decode.py
@@ -2510,7 +2510,7 @@ def main():
     arg_parse.add_argument('--bitdate', metavar='', help='convert from a Samsung/LG 4-byte value')
     arg_parse.add_argument('--bitdec', metavar='', help='convert from a bitwise decimal 10-digit value')
     arg_parse.add_argument('--bplist', metavar='', help='convert from an iOS Binary Plist value')
-    arg_parse.add_argument('--cocoa', metavar='', help='convert from Cocoa')
+    arg_parse.add_argument('--cocoa', metavar='', help='convert from Cocoa Core')
     arg_parse.add_argument('--chrome', metavar='', help='convert from Google Chrome value')
     arg_parse.add_argument('--cookie', metavar='', help='convert from Windows Cookie Date (Low,High)')
     arg_parse.add_argument('--dhcp6', metavar='', help='convert from a DHCP6 DUID value')

--- a/time_decode/time_decode.py
+++ b/time_decode/time_decode.py
@@ -1551,11 +1551,11 @@ class TimeDecoder():
             self.out_eitime = ts_output = False
         return self.out_eitime, ts_output
 
-    def from_bplist(self, ts_type=None):
+    def from_bplist(self):
         """Convert a Binary Plist timestamp to a date"""
         reason = "[!] Binary Plist/Cocoa timestamps are 9 digits"
-        if not ts_type:
-            ts_type = self.ts_types['bplist']
+        ts_type = self.ts_types['bplist']
+
         try:
             if not len(self.bplist) == 9 or not self.bplist.isdigit():
                 self.in_bplist = indiv_output = combined_output = False
@@ -2461,7 +2461,7 @@ class TimeDecoder():
     def to_cocoa(self):
         """Convert date to a Cocoa timestamp"""
         return self.to_bplist()
-    
+
     @staticmethod
     def date_range(start, end, check_date):
         """Check if date is in range of start and end, return True if it is"""

--- a/time_decode/time_decode.py
+++ b/time_decode/time_decode.py
@@ -23,9 +23,10 @@ Microsoft FILETIME:
     https://support.microsoft.com/en-ca/help/188768/info-working-with-the-filetime-structure
 Microsoft Active Directory/LDAP Timestamp:
     https://docs.microsoft.com/en-us/windows/win32/adschema/a-lastlogontimestamp
-bplist timestamp / Mac Absolute
+bplist timestamp / Mac Absolute / Cocoa Core
     https://developer.apple.com/documentation/corefoundation/cfabsolutetime
     https://developer.apple.com/documentation/foundation/nsdate
+    https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/DatesAndTimes/Articles/dtDates.html
 GSM Timestamps:
     https://en.wikipedia.org/wiki/GSM_03.40
     http://seven-bit-forensics.blogspot.com/2014/02/decoding-gsmsms-timestamps.html
@@ -63,8 +64,6 @@ Bitwise Decimal Timestamp
     Source of TS unknown, but since it's seemingly rare, it may be useful
 BitDate
     https://sqliteforensictoolkit.com/a-brief-history-of-time-stamps/
-Cocoa
-    https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/DatesAndTimes/Articles/dtDates.html
 """
 
 from datetime import datetime as dt, timedelta
@@ -135,7 +134,6 @@ class TimeDecoder():
             'active': 116444736000000000,
             'hfs_dec_sub': 2082844800,
             'kstime': 1400000000,
-            'cocoa': 978303600
         }
         self.single_funcs = {
             self.unix: self.from_unix_sec, self.umil: self.from_unix_milli,
@@ -2512,7 +2510,7 @@ def main():
     arg_parse.add_argument('--bitdate', metavar='', help='convert from a Samsung/LG 4-byte value')
     arg_parse.add_argument('--bitdec', metavar='', help='convert from a bitwise decimal 10-digit value')
     arg_parse.add_argument('--bplist', metavar='', help='convert from an iOS Binary Plist value')
-    arg_parse.add_argument('--cocoa', metavar='', help='convert from cocoa')
+    arg_parse.add_argument('--cocoa', metavar='', help='convert from Cocoa')
     arg_parse.add_argument('--chrome', metavar='', help='convert from Google Chrome value')
     arg_parse.add_argument('--cookie', metavar='', help='convert from Windows Cookie Date (Low,High)')
     arg_parse.add_argument('--dhcp6', metavar='', help='convert from a DHCP6 DUID value')


### PR DESCRIPTION
Dear @digitalsleuth, 

this PR adds support for Apple's Cocoa Core timestamp, which is currently commonly used in Apple health data (`healthdb_secure`,...). More information on the timestamp can be found [here](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/DatesAndTimes/Articles/dtDates.html).

Thanks for considering this PR.

Best regards,
jgru