### PR TITLE
v10.2.0 - timezone placement fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ exclude = ["debian*", "binaries*", "build*", "dist*"]
 
 [project]
 name = "time-decode"
-version = "10.1.0"
+version = "10.2.0"
 dependencies = [
     "PyQt6",
     "colorama",

--- a/time-decode-gui.spec
+++ b/time-decode-gui.spec
@@ -1,6 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-__version__ = '10.1.0'
+__version__ = '10.2.0'
 
 a = Analysis(
     ['time_decode/time_decode.py'],

--- a/time-decode-mac.spec
+++ b/time-decode-mac.spec
@@ -1,6 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-__version__ = "10.1.0"
+__version__ = "10.2.0"
 bundle_id = "com.digitalsleuth.time-decode"
 block_cipher = None
 
@@ -52,7 +52,7 @@ app = BUNDLE(coll,
                  'CFBundleDisplayName': 'Time Decode',
                  'CFBundleExecutable': 'Time Decode',
                  'CFBundleIdentifier': bundle_id,
-                 'CFBundleShortVersionString': '10.1.0',
-                 'CFBundleVersion': '10.1.0',
+                 'CFBundleShortVersionString': '10.2.0',
+                 'CFBundleVersion': '10.2.0',
              },
              bundle_identifier=bundle_id)

--- a/time-decode.spec
+++ b/time-decode.spec
@@ -1,6 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-__version__ = '10.1.0'
+__version__ = '10.2.0'
 
 a = Analysis(
     ['time_decode/time_decode.py'],

--- a/time_decode/time_decode.py
+++ b/time_decode/time_decode.py
@@ -70,8 +70,8 @@ from PyQt6.QtWidgets import (
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 init(autoreset=True)
 __author__ = "Corey Forman (digitalsleuth)"
-__date__ = "2025-05-25"
-__version__ = "10.1.0"
+__date__ = "2025-10-28"
+__version__ = "10.2.0"
 __description__ = "Python 3 Date Time Conversion Tool"
 __fmt__ = "%Y-%m-%d %H:%M:%S.%f"
 __red__ = "\033[1;31m"
@@ -5296,8 +5296,8 @@ def format_output(ts_type, ts, tz=None):
     elif len(ts_type) in range(23, 32):
         tabs = "\t"
     if tz:
-        indiv_output = f"{ts_type}: {ts}{tz}"
-        combined_output = f"{__red__}{ts_type}:{tabs}{ts}{tz}{__clr__}"
+        indiv_output = f"{ts_type}: {ts} {tz}"
+        combined_output = f"{__red__}{ts_type}:{tabs}{ts} {tz}{__clr__}"
     else:
         indiv_output = f"{ts_type}:{tabs}{ts}"
         combined_output = None

--- a/version.txt
+++ b/version.txt
@@ -1,14 +1,14 @@
 # https://learn.microsoft.com/en-us/windows/win32/api/verrsrc/ns-verrsrc-vs_fixedfileinfo
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(10,1,0,0),
-    prodvers=(10,1,0,0),
+    filevers=(10,2,0,0),
+    prodvers=(10,2,0,0),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
     fileType=0x1,
     subtype=0x0,
-    date=(0x01dbcce4,0x1e4f534c)
+    date=(0x01dc4874,0x605d5d90)
     ),
   kids=[
     StringFileInfo(
@@ -17,12 +17,12 @@ VSVersionInfo(
         u'040904B0',
         [StringStruct(u'CompanyName', u'Digital Sleuth'),
         StringStruct(u'FileDescription', u'Timestamp encode/decode utility for over 60 timestamps'),
-        StringStruct(u'FileVersion', u'10.1.0'),
+        StringStruct(u'FileVersion', u'10.2.0'),
         StringStruct(u'InternalName', u'Time Decode'),
         StringStruct(u'LegalCopyright', u'© 2025 Digital Sleuth'),
-        StringStruct(u'OriginalFilename', u'Time Decode GUI v10.1.0.exe'),
-        StringStruct(u'ProductName', u'Time Decode GUI v10.1.0'),
-        StringStruct(u'ProductVersion', u'10.1.0')])
+        StringStruct(u'OriginalFilename', u'Time Decode GUI v10.2.0.exe'),
+        StringStruct(u'ProductName', u'Time Decode GUI v10.2.0'),
+        StringStruct(u'ProductVersion', u'10.2.0')])
       ]), 
     VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
   ]


### PR DESCRIPTION
The missing space between the timezone and the timestamp for output was causing some issues when parsing the output timestamp. This has been fixed.